### PR TITLE
Prometheus gauge for player counts

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,7 @@ app.use('/api/logs', require('./routes/logs')(logs))
 app.use('/api/missions', require('./routes/missions')(missions))
 app.use('/api/mods', require('./routes/mods')(mods))
 app.use('/api/servers', require('./routes/servers')(manager, mods))
+app.use('/metrics', require('./routes/prometheus')(manager))
 app.use('/api/settings', require('./routes/settings')(config))
 
 io.on('connection', function (socket) {

--- a/lib/server-log-writer.js
+++ b/lib/server-log-writer.js
@@ -5,11 +5,9 @@ var logger = require('./logger').getLogger('server-log-writer')
 
 var logPaths = new logPathModule(config);
 
-
 var rptAnalyzers = (config.rptAnalyzers || []).map(function(rptAnalyzer) {
   return require('./rpt-analyzer/' + rptAnalyzer)
 })
-
 
 function logInstance(server, instance, logFileName) {
   var callRptAnalyzers = function (data) {
@@ -48,4 +46,8 @@ module.exports.setupFileLog = function (server) {
   server.headlessClientInstances.forEach(function (hcInstance, idx) {
     logInstance(server, hcInstance, logPaths.generateLogFilePath(subdir, 'hc' + idx))
   })
+}
+
+module.exports.addRptAnalyzer = function (rptAnalyzer) {
+  rptAnalyzers.push(rptAnalyzer)
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash": "^3.6.0",
     "multer": "^1.3.0",
     "playwithsix": "0.0.13",
+    "prom-client": "^10.0.0",
     "serve-static": "^1.12.1",
     "slugify": "^1.1.0",
     "socket.io": "^1.0.4",

--- a/routes/prometheus.js
+++ b/routes/prometheus.js
@@ -1,0 +1,56 @@
+let express = require('express')
+let promclient = require('prom-client');
+let serverLogWriter = require('../lib/server-log-writer')
+
+let connectedPlayers = new promclient.Gauge({
+    name: 'arma3_players_connected',
+    help: 'Number of connected players on an arma3 server',
+    labelNames: ['game', 'title', 'hostname', 'port']
+})
+
+let configuredServers = new promclient.Gauge({
+    name: 'arma3_servers_configured',
+    help: 'Number of servers configured'
+})
+
+let runningServers = new promclient.Gauge({
+    name: 'arma3_servers_running',
+    help: 'Number of servers running'
+})
+
+let runningHCs = new promclient.Gauge({
+    name: 'arma3_hcs_running',
+    help: 'Number of headless clients running',
+    labelNames: ['game', 'title', 'hostname', 'port']
+})
+
+
+let lineCounter = new promclient.Counter({
+    name: 'arma3_log_lines',
+    help: 'Number of log lines written',
+    labelNames: ['game', 'title', 'hostname', 'port']
+})
+
+serverLogWriter.addRptAnalyzer(function (server, instance, line) {
+    lineCounter.labels(server.game, server.title, server.hostname, server.port).inc()
+})
+
+module.exports = function (manager) { // server manager
+    var router = express.Router()
+
+    router.get('/', function (req, res) {
+        connectedPlayers.reset()
+        runningHCs.reset()
+        manager.getServers().filter(function (server) {
+            return !!server.instance
+        }).forEach(function (server) {
+            connectedPlayers.labels(server.game, server.title, server.hostname, server.port).set((server.players || []).length)
+            runningHCs.labels(server.game, server.title, server.hostname, server.port).set(server.headlessClientInstances.length)
+        })
+        configuredServers.set(manager.getServers().length)
+        runningServers.set(manager.getServers().filter(function (server) { return server.instance }).length)
+        res.end(promclient.register.metrics());
+    })
+
+    return router
+}


### PR DESCRIPTION
export lots of metrics to /metrics (to be consumed by Prometheus)

```
# HELP arma3_players_connected Number of connected players on an arma3 server
# TYPE arma3_players_connected gauge
arma3_players_connected{game="undefined",title="Gruppe Adler - Adlerbase (2302)",hostname="undefined",port="2302"} 0

# HELP arma3_servers_configured Number of servers configured
# TYPE arma3_servers_configured gauge
arma3_servers_configured 7

# HELP arma3_servers_running Number of servers running
# TYPE arma3_servers_running gauge
arma3_servers_running 1

# HELP arma3_hcs_running Number of headless clients running
# TYPE arma3_hcs_running gauge
arma3_hcs_running{game="undefined",title="Gruppe Adler - Adlerbase (2302)",hostname="undefined",port="2302"} 1

# HELP arma3_log_lines Number of log lines written
# TYPE arma3_log_lines counter
arma3_log_lines{game="undefined",title="Gruppe Adler - Adlerbase (2302)",hostname="undefined",port="2302"} 659
arma3_log_lines{game="undefined",title="Gruppe Adler - Testserver (2402) ",hostname="undefined",port="2402"} 632
```